### PR TITLE
Add: agency-os — Notion-based AI agency orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@
 - **[Autogen](https://github.com/microsoft/autogen)** ⭐ 32k+ - Enable Next-Gen Large Language Model Applications
 
 - **[OpenPaw](https://github.com/daxaur/openpaw)** - Open-source CLI tool (`npx pawmode`) that turns Claude Code into a personal assistant with 38 skills. No daemon, no cloud, MIT licensed.
+- **[agency-os](https://github.com/ratamaha-git/agency-os)** - Run your work like an AI agency from a single Notion board. Plan ideas into dependency-sequenced subtasks, dispatch each on the right model, and collect results back in Notion. Pluggable to Claude Code, Cursor, Cline, or any MCP-compatible agent.
 
 ### Development Platforms
 


### PR DESCRIPTION
## What this adds

**[agency-os](https://github.com/ratamaha-git/agency-os)** — Run your work like an AI agency from a single Notion board. Plan ideas into dependency-sequenced subtasks, dispatch each on the right model (Haiku/Sonnet/Opus), and collect results back in Notion. Pluggable to Claude Code, Cursor, Cline, or any MCP-compatible agent.

Added to the **Multi-Agent Orchestration** section under Frameworks & Platforms.

## Checklist
- [x] Open source (MIT licensed)
- [x] Publicly available on GitHub
- [x] Well-documented with setup instructions
- [x] Actively maintained (last commit within the last 6 months)
- [x] Unique functionality: Notion-native task board as AI dispatch control plane