### PR TITLE
feat: add CreatorSkills to Creative & Content section

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
 - **[ChatGPT-Writer](https://github.com/gpt-writer/ChatGPT-Writer)** - Browser extension to write emails, messages, and more using ChatGPT
 - **[AI-Commit](https://github.com/guanguans/ai-commit)** - Automagically generate conventional commit messages with AI
 - **[Storyteller](https://github.com/jaketae/storyteller)** - Generate stories using GPT models
+- **[CreatorSkills](https://creatorskills.co)** - Marketplace of 30+ downloadable AI skills for content creators covering YouTube scripting, sponsorship analysis, and audience growth. Works with Claude and ChatGPT.
 
 ### Research & Analysis
 


### PR DESCRIPTION
Adds [CreatorSkills](https://creatorskills.co) to the Creative & Content section under ChatGPT Agents.

CreatorSkills is a marketplace of 30+ downloadable AI skill files for content creators — covering YouTube scripting, sponsorship analysis, audience growth, and more. Skills install into Claude and ChatGPT as persistent instructions, turning a general-purpose model into a specialist tool for creator workflows.

- Works with both ChatGPT and Claude
- Skill formats: SKILL.md (Agent Skills open standard) + .mdc (Cursor)
- 30+ skills across scripting, titles/thumbnails, sponsorship analysis, course creation, and audience growth