### PR TITLE
feat: add NotFair — open-source Claude Code skills for SEO and paid ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@
 - **[lst97/claude-code-sub-agents](https://github.com/lst97/claude-code-sub-agents)** - Specialized subagents for the entire software development lifecycle
 - **[vijaythecoder/awesome-claude-agents](https://github.com/vijaythecoder/awesome-claude-agents)** - 24 specialized agents working together to build production-ready features
 - **[toprank](https://github.com/nowork-studio/toprank)** - Open-source Claude Code plugin with 9 SEO and Google Ads skills — connects Google Search Console, PageSpeed Insights, and Google Ads API
+- **[NotFair](https://github.com/nowork-studio/NotFair)** ⭐ 2.9k+ - Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads — connects live marketing data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP
 
 
 ### Full-Stack & DevOps


### PR DESCRIPTION
Thanks for maintaining this list — it's a great resource.

I'd like to add **[NotFair](https://github.com/nowork-studio/NotFair)** (~2.9k stars, MIT), an open-source set of Claude Code skills focused on marketing work: SEO/GEO analysis, Google Ads management, and Meta (Facebook + Instagram) Ads. It pulls live data through Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.

I've placed it in the **Specialized Development** section, right next to the existing toprank entry (same team, NotFair is the current project). The format matches the surrounding entries.

Happy to reword, move, or trim the description if you'd prefer something different.